### PR TITLE
docs: update readme structure and introduce global caution disclaimer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,28 @@
-# (Unofficial) report template for HCMUS
+# 🎓 Unofficial LaTeX Templates for HCMUS
 
-This repository stores the source code for LaTeX templates designed for students and researchers of the Ho Chi Minh City University of Science (HCMUS):
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
+[![Wiki](https://img.shields.io/badge/Documentation-Wiki-brightgreen.svg)](https://github.com/khongsomeo/hcmus-unofficial-report-template/wiki)
 
-- **`report`**: [Report Template on Overleaf](https://www.overleaf.com/latex/templates/hcmus-report-template/zyrhmsxynwqs)
-- **`thesis`**: Unofficial Master Thesis Template (available in `thesis/master`, detailed documentation in the [Project Wiki](https://github.com/khongsomeo/hcmus-unofficial-report-template/wiki))
+This repository provides LaTeX templates designed for students and researchers at the Ho Chi Minh City University of Science (HCMUS). All detailed user guides, configuration steps, layout previews, and compilation instructions are unified in the project Wiki.
+
+👉 **[Go to Project Wiki Documentation](https://github.com/khongsomeo/hcmus-unofficial-report-template/wiki)**
+
+> [!CAUTION]
+> **These templates are unofficial, entirely community-run, and not endorsed by HCMUS.**
+> 
+> It is provided 100% free of charge via this official repository and the listed Overleaf links. If you paid money for this, you have been scammed. 
+> We make no guarantees that your department's formatting committee won't reject this layout (along with your graduation timeline). Please consult your academic office or advisor before use to save your own sanity. We also take zero responsibility for sketchy copies downloaded from random third-party forums.
+> 
+> If it compiles and breaks, you get to keep both pieces. To report bugs or offer therapy to the maintainers, please open an issue or write to `thquan (at) fit.hcmus.edu.vn`.
 
 ---
 
-## 📖 Wiki Documentation
+## 🗂️ Available Templates
 
-All detailed user guides, configuration steps, layout previews, and compilation instructions are available on the project Wiki:
-
-👉 **[Go to Project Wiki Documentation](https://github.com/khongsomeo/hcmus-unofficial-report-template/wiki)**
+| Template | Folder Position | Launch on Overleaf | Documentation |
+| :--- | :--- | :---: | :--- |
+| **Course Report** | [report/](report) | [![Overleaf](https://img.shields.io/badge/Overleaf-Template-35713B?style=flat&logo=Overleaf&logoColor=white)](https://www.overleaf.com/latex/templates/hcmus-report-template/zyrhmsxynwqs) | [Report Guide](https://github.com/khongsomeo/hcmus-unofficial-report-template/wiki/Report) |
+| **Master's Thesis** | [thesis/master/](thesis/master) | — | [Thesis Guide](https://github.com/khongsomeo/hcmus-unofficial-report-template/wiki/Master-Thesis) |
 
 ---
 


### PR DESCRIPTION
# docs: update readme structure and introduce global caution disclaimer

## 1. Description
This PR updates the repository's root `readme.md` to establish a clean and clear templates catalog, and to present the global disclaimer warning for all templates.

## 2. Related Issues
None

### Details of Changes:
- **Redesigned Templates Registry**: Updated the layout registry table in `readme.md` to map and link the Course Report and Master's Thesis templates to their respective documentation guides.
- **Added Badges**: Included status badge links for project licensing and documentation wiki access.
- **Injected Global Warning Banner**: Implemented the humorous global warning notice detailing that these templates are unofficial, community-run, and not officially endorsed by the institution.

## 3. Type of Change
Please check the options that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code cleanup, performance improvement, no API changes)
- [x] Documentation update

## 4. How Has This Been Tested?
- Verified rendering of the updated `readme.md` on the repository homepage.

## 5. Checklist
Before submitting, please ensure:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.