### PR TITLE
fix(quiz): fix correct choice circle and answer key tracking in choices env

### DIFF
--- a/quiz/hcmusquiz.cls
+++ b/quiz/hcmusquiz.cls
@@ -199,22 +199,45 @@
   }%
   {\if@correctchoice \endgroup \fi}
 
-% --- Align choices indentation with oneparchoices first choice and track answers ---
-\renewcommand{\choiceshook}{%
-  \settowidth{\leftmargin}{A.\hskip\labelsep}%
-  \labelwidth\leftmargin\advance\labelwidth-\labelsep
-  \if@filesw
-    \immediate\write\@auxout{\string\global\string\@namedef{mcq@isquestion@\the\value{question}}{1}}%
-  \fi
-  \let\old@CorrectChoice\CorrectChoice
-  \def\CorrectChoice{%
-    \old@CorrectChoice
-    \if@filesw
-      \immediate\write\@auxout{\string\global\string\@namedef{correctans@\the\value{question}}{\Alph{choice}}}%
-    \fi
+% --- Custom choices environment to ensure circled correct choice labels render correctly ---
+\renewenvironment{choices}%
+  {\list{\choicelabel}%
+     {\usecounter{choice}%
+      \let\old@item\item
+      \def\item{%
+        \old@item
+        \def\makelabel####1{\hss\llap{####1}}%
+      }% item
+      \settowidth{\leftmargin}{A.\hskip\labelsep}%
+      \labelwidth\leftmargin\advance\labelwidth-\labelsep
+      \if@filesw
+        \immediate\write\@auxout{\string\global\string\@namedef{mcq@isquestion@\the\value{question}}{1}}%
+      \fi
+      \def\choice{%
+        \if@correctchoice \color@endgroup \endgroup \fi
+        \item
+        \do@choice@pageinfo
+      }% choice
+      \def\CorrectChoice{%
+        \if@correctchoice \color@endgroup \endgroup \fi
+        \ifprintanswers
+          \ifhmode \unskip\unskip\unvbox\voidb@x \fi
+          \begingroup \color@begingroup \@correctchoicetrue
+          \CorrectChoice@Emphasis
+        \fi
+        \item
+        \do@choice@pageinfo
+        \if@filesw
+          \immediate\write\@auxout{\string\global\string\@namedef{correctans@\the\value{question}}{\Alph{choice}}}%
+        \fi
+      }% CorrectChoice
+      \let\correctchoice\CorrectChoice
+      \choiceshook
+     }%
   }%
-  \let\correctchoice\CorrectChoice
-}
+  {\if@correctchoice \color@endgroup \endgroup \fi \endlist}
+
+\renewcommand{\choiceshook}{}
 
 % --- MCQ Answer Box Feature ---
 \newcount\mcq@i


### PR DESCRIPTION
# fix(quiz): fix correct choice circle and answer key tracking in choices env

## 1. Description
This PR completely redefines the `choices` environment inside `hcmusquiz.cls` to ensure that correct choice circles and answer tracking behave correctly and robustly, particularly in newer TeX Live environments (like TeX Live 2025 in Overleaf Community Edition).

## 2. Related Issues
None

### Details of Changes:
- **Redefined `choices` Environment**: Completely redefined `choices` using `\renewenvironment` in `hcmusquiz.cls` instead of patching `\choiceshook`. This ensures that local changes to `\CorrectChoice` and `\correctchoice` are scoped correctly inside the environment and are not discarded by `enumitem` calculations in newer TeX Live installations.
- **Fixed Aux-Write Counter Evaluation Order**: Adjusted the evaluation order inside `\CorrectChoice` to write the correct choice letter to the `.aux` file *after* `\item` is processed, ensuring the counter is fully incremented to the correct option index (A, B, C, D) before writing, which fixes missing labels on MCQ answer sheets.

## 3. Type of Change
Please check the options that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Refactoring (code cleanup, performance improvement, no API changes)
- [] Documentation update

## 4. How Has This Been Tested?
- Compiled `main.tex` under `quiz/` with `build.sh` both in student and answer-key mode (`\printanswers` enabled).
- Verified that correct choice circles and MCQ Answer Sheets (Table and Circle styles) are rendered correctly in PDF output and the `.aux` file receives correct option mappings (e.g. `correctans@1` gets `A` instead of empty).

## 5. Checklist
Before submitting, please ensure:
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.